### PR TITLE
Enable Restify ServerOptions to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ let app = server.build();
 app.listen(3000);
 ```
 
+Restify ServerOptions can be provided as a second parameter to the InversifyRestifyServer constructor:
+
+```let server = new InversifyRestifyServer(kernel, { name: "my-server" });```
+
 ## InversifyRestifyServer
 A wrapper for a restify Application.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { TYPE, METADATA_KEY } from "./constants";
  */
 export class InversifyRestifyServer  {
     private kernel: inversify.interfaces.Kernel;
-    private app: restify.Server = restify.createServer();
+    private app: restify.Server;
     private configFn: interfaces.ConfigFunction;
 
     /**
@@ -16,8 +16,9 @@ export class InversifyRestifyServer  {
      *
      * @param kernel Kernel loaded with all controllers and their dependencies.
      */
-    constructor(kernel: inversify.interfaces.Kernel) {
+    constructor(kernel: inversify.interfaces.Kernel, opts?: restify.ServerOptions) {
         this.kernel = kernel;
+        this.app = restify.createServer(opts);
     }
 
     /**

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -122,6 +122,30 @@ describe("Integration Tests:", () => {
                 .get("/")
                 .expect(200, JSON.stringify(result), done);
         });
+
+        it("should allow server options", (done) => {
+            let result = {"hello": "world"};
+            let customHeaderName = "custom-header-name";
+            let customHeaderValue = "custom-header-value";
+
+            @injectable()
+            @Controller("/")
+            class TestController {
+                @Get("/") public getTest(req: restify.Request, res: restify.Response) { return result; }
+            }
+            kernel.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyRestifyServer(kernel, { formatters: {
+                "application/json": function formatFoo(req: restify.Request, res: restify.Response, body: any, cb: any) {
+                    res.setHeader(customHeaderName, customHeaderValue);
+                    return cb();
+                }
+            } });
+            request(server.build())
+                .get("/")
+                .expect(customHeaderName, customHeaderValue)
+                .expect(200, done);
+        });
     });
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds an extra parameter when creating the InversifyRestifyServer to allow the user to specify Restify ServerOptions (eg custom formatters) 

## Related Issue
https://github.com/inversify/InversifyJS/issues/383
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Without this it's not possible to use custom formatters, a custom logger or any other feature of Restify that requires custom options.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Ran unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.