### PR TITLE
fix (export): Interfaces were not exported in index.ts.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import { InversifyRestifyServer } from "./server";
 import { Controller, Method, Get, Put, Post, Patch, Head, Options, Delete } from "./decorators";
 import { TYPE } from "./constants";
+import interfaces from "./interfaces";
 
 export {
+	interfaces,
     InversifyRestifyServer,
     Controller,
     Method,


### PR DESCRIPTION
I have added an import of interfaces file in index.ts and exported interfaces.

## Description
I had issues compiling a project with this repo code. I checked inversify-express-utils repo and found that interfaces were not exported in inversify-restify-utils.
