### PR TITLE
Support specifying restify route options via Get, Post etc annotations

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,37 +9,38 @@ export function Controller(path: string, ...middleware: restify.RequestHandler[]
     };
 }
 
-export function Get   (path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("get",    path, ...middleware);
+export function Get(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("get", options, ...middleware);
 }
 
-export function Post  (path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("post",   path, ...middleware);
+export function Post(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("post", options, ...middleware);
 }
 
-export function Put   (path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("put",    path, ...middleware);
+export function Put(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("put", options, ...middleware);
 }
 
-export function Patch (path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("patch",  path, ...middleware);
+export function Patch(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("patch", options, ...middleware);
 }
 
-export function Head  (path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("head",   path, ...middleware);
+export function Head(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("head", options, ...middleware);
 }
 
-export function Delete(path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("del", path, ...middleware);
+export function Delete(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("del", options, ...middleware);
 }
 
-export function Options(path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
-    return Method("opts", path, ...middleware);
+export function Options(options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+    return Method("opts", options, ...middleware);
 }
 
-export function Method(method: string, path: string, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Method(
+        method: string, options: interfaces.RouteOptons, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
     return function (target: any, key: string, value: any) {
-        let metadata: interfaces.ControllerMethodMetadata = {path, middleware, method, target, key};
+        let metadata: interfaces.ControllerMethodMetadata = {options, middleware, method, target, key};
         let metadataList: interfaces.ControllerMethodMetadata[] = [];
 
         if (!Reflect.hasOwnMetadata(METADATA_KEY.controllerMethod, target.constructor)) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,7 +8,12 @@ namespace interfaces {
         target: any;
     }
 
-    export interface ControllerMethodMetadata extends ControllerMetadata {
+    export type RouteOptons = string | { path: string } & Object;
+
+    export interface ControllerMethodMetadata {
+        options: RouteOptons;
+        middleware: restify.RequestHandler[];
+        target: any;
         method: string;
         key: string;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,11 +67,11 @@ export class InversifyRestifyServer  {
             if (controllerMetadata && methodMetadata) {
                 methodMetadata.forEach((metadata: interfaces.ControllerMethodMetadata) => {
                     let handler: restify.RequestHandler = this.handlerFactory(controllerMetadata.target.name, metadata.key);
-                    let fullPath = metadata.path;
+                    let routeOptions = typeof metadata.options === "string" ? { path: metadata.options } : metadata.options;
                     if (controllerMetadata.path !== "/") {
-                        fullPath = controllerMetadata.path + metadata.path;
+                        routeOptions.path = controllerMetadata.path + routeOptions.path;
                     }
-                    this.app[metadata.method](fullPath, [...controllerMetadata.middleware, ...metadata.middleware], handler);
+                    this.app[metadata.method](routeOptions, [...controllerMetadata.middleware, ...metadata.middleware], handler);
                 });
             }
         });
@@ -89,9 +89,9 @@ export class InversifyRestifyServer  {
                         res.send(value);
                     }
                 })
-                    .catch((error: any) => {
-                        next(new Error(error));
-                    });
+                .catch((error: any) => {
+                    next(new Error(error));
+                });
 
             } else if (result && !res.headersSent) {
                 res.send(result);

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -46,7 +46,7 @@ describe("Unit Test: Controller Decorators", () => {
         let metadata: interfaces.ControllerMethodMetadata = methodMetadata[0];
 
         expect(metadata.middleware).eql(middleware);
-        expect(metadata.path).eql(path);
+        expect(metadata.options).eql(path);
         expect(metadata.target.constructor).eql(TestController);
         expect(metadata.key).eql("test");
         expect(metadata.method).eql(method);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -5,12 +5,13 @@ import * as sinon from "sinon";
 // dependencies
 import * as restify from "restify";
 import { InversifyRestifyServer } from "../src/server";
+import { Controller, Method } from "../src/decorators";
 import { Container, injectable } from "inversify";
 import { TYPE } from "../src/constants";
 
 describe("Unit Test: InversifyRestifyServer", () => {
 
-    it("should call the configFn", (done) => {
+    it("should call the configFn", () => {
         let middleware = function(req: restify.Request, res: restify.Response, next: restify.Next) { return; };
         let configFn = sinon.spy((app: restify.Server) => { app.use(middleware); });
         let container = new Container();
@@ -28,6 +29,30 @@ describe("Unit Test: InversifyRestifyServer", () => {
         server.build();
 
         expect(configFn.calledOnce).to.be.true;
-        done();
+    });
+
+    it("should generate routes for controller methods", () => {
+
+        @injectable()
+        @Controller("/root")
+        class TestController {
+            @Method("get", "/routeOne")
+            public routeOne() { return; }
+
+            @Method("get", { additionalOptions: "test", path: "/routeTwo" })
+            public routeTwo() { return; }
+        }
+
+        let container = new Container();
+        container.bind(TYPE.Controller).to(TestController);
+        let server = new InversifyRestifyServer(container);
+        let app = server.build();
+
+        let routeOne = app.router.routes.GET.find(route => route.spec.path === "/root/routeOne");
+        expect(routeOne).not.to.be.undefined;
+
+        let routeTwo = app.router.routes.GET.find(route => route.spec.path === "/root/routeTwo");
+        expect(routeTwo).not.to.be.undefined;
+        expect((<any>routeTwo.spec).additionalOptions).to.eq("test");
     });
 });


### PR DESCRIPTION
Implemented changes allow specifying additional restify route options via Get, Post etc annotations.

## Description

Now controller method annotations allows to specify route path or path and any other route options.

## Related Issue
https://github.com/inversify/InversifyJS/issues/412

## Motivation and Context
Restify uses route options for versioning as well as some restify extensions use route options as as configuration. Implemented change allows to specify route options via annotations .

## How Has This Been Tested?
Unit test has been added.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
