### PR TITLE
Use interfaces to access Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ The following example will declare a controller that responds to `GET /foo'.
 
 ```ts
 import * as restify from 'restify';
-import { Controller, Get } from 'inversify-restify-utils';
+import { Controller, Get, interfaces } from 'inversify-restify-utils';
 import { injectable, inject } from 'inversify';
 
 @Controller('/foo')
 @injectable()
-export class FooController implements Controller {
+export class FooController implements interfaces.Controller {
     
     constructor( @inject('FooService') private fooService: FooService ) {}
     
@@ -59,13 +59,13 @@ The `Controller` interface exported by inversify-restify-utils is empty and sole
 
 ```ts
 import { Container } from 'inversify';
-import { InversifyRestifyServer, TYPE } from 'inversify-restify-utils';
+import { interfaces, InversifyRestifyServer, TYPE } from 'inversify-restify-utils';
 
 // set up container
 let container = new Container();
 
 // note that you *must* bind your controllers to Controller 
-container.bind<Controller>(TYPE.Controller).to(FooController).whenTargetNamed('FooController');
+container.bind<interfaces.Controller>(TYPE.Controller).to(FooController).whenTargetNamed('FooController');
 container.bind<FooService>('FooService').to(FooService);
 
 // create server


### PR DESCRIPTION
The current documentation is using `Controller` directly from the `inversify-restify-utils`. However this leads to a TS error `Cannot find name 'Controller'`.

We should import the `Controller` interface from the `interfaces` literal. This PR simply fixes the `README`.

## Description
Use `interfaces.Controller` instead of `Controller`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
