### PR TITLE
nvm-regression-tests: Fixing nvm regression tests by providing types …

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,7 +8,8 @@ namespace interfaces {
         target: any;
     }
 
-    export type RouteOptions = string | RegExp | { path: string | RegExp  } & Object;
+    export type StrOrRegex = string | RegExp;
+    export type RouteOptions = StrOrRegex | { path: StrOrRegex  } | { options: Object, path: StrOrRegex } & Object;
 
     export interface ControllerMethodMetadata {
         options: RouteOptions;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -36,8 +36,11 @@ describe("Unit Test: InversifyRestifyServer", () => {
             @Method("get", "/routeOne")
             public routeOne() { return; }
 
-            @Method("get", { additionalOptions: "test", path: "/routeTwo" })
+            @Method("get", { options: "test", path: "/routeTwo" })
             public routeTwo() { return; }
+
+            @Method("get", { path: "/routeThree" })
+            public routeThree() { return; }
         }
 
         let container = new Container();
@@ -50,7 +53,10 @@ describe("Unit Test: InversifyRestifyServer", () => {
 
         let routeTwo = app.router.routes.GET.find(route => route.spec.path === "/root/routeTwo");
         expect(routeTwo).not.to.be.undefined;
-        expect((<any>routeTwo).spec.additionalOptions).to.eq("test");
+        expect((<any>routeTwo).spec.options).to.eq("test");
+
+        let routeThree = app.router.routes.GET.find(route => route.spec.path === "/root/routeThree");
+        expect(routeThree).not.to.be.undefined;
 
     });
 });


### PR DESCRIPTION
…for RouteOptions

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Travis complains when running the build for old node versions for example
https://travis-ci.org/inversify/inversify-restify-utils/jobs/248936537
```
test/server.test.ts(39,30): error TS2345: Argument of type '{ additionalOptions: string; path: string; }' is not assignable to parameter of type 'RouteOptions'.
  Object literal may only specify known properties, and 'additionalOptions' does not exist in type 'RouteOptions'.
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[601](https://github.com/inversify/InversifyJS/issues/601)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running all tests in Travis results in them failing for old node releases. With this fix, I added
a simple type for the RouteOptions so that the tests pass.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added one more test to verify that the `RouteOptions` type does not break the build in older node versions
See https://travis-ci.org/theodesp/inversify-restify-utils/builds/251146999

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
