### PR TITLE
Default root option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Restify ServerOptions can be provided as a second parameter to the InversifyRest
 
 ```let server = new InversifyRestifyServer(container, { name: "my-server" });```
 
+Restify ServerOptions can be extended with `defaultRoot` where one can define a default path that will be prepended to all your controllers:
+
+```let server = new InversifyRestifyServer(container, { name: "my-server", defaultRoot: "/v1" });```
+
 ## InversifyRestifyServer
 A wrapper for a restify Application.
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,9 @@ namespace interfaces {
         (app: restify.Server): void;
     }
 
+    export interface ServerOptions extends restify.ServerOptions {
+      defaultRoot?: string;
+    }
 }
 
 export { interfaces };

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -143,6 +143,30 @@ describe("Integration Tests:", () => {
                 .expect(customHeaderName, customHeaderValue)
                 .expect(200, done);
         });
+        
+        it("should allow server options with defaultRoot", (done) => {
+            let result = {"hello": "world"};
+            let customHeaderName = "custom-header-name";
+            let customHeaderValue = "custom-header-value";
+
+            @injectable()
+            @Controller("/")
+            class TestController {
+                @Get("/") public getTest(req: restify.Request, res: restify.Response) { return result; }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyRestifyServer(container, { formatters: {
+                "application/json": function formatFoo(req: restify.Request, res: restify.Response, body: any, cb: any) {
+                    res.setHeader(customHeaderName, customHeaderValue);
+                    return cb();
+                }
+            }, defaultRoot: "/v1" });
+            request(server.build())
+                .get("/v1")
+                .expect(customHeaderName, customHeaderValue)
+                .expect(200, done);
+        });
     });
 
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -55,7 +55,41 @@ describe("Unit Test: InversifyRestifyServer", () => {
         expect(routeTwo).not.to.be.undefined;
         expect((<any>routeTwo).spec.options).to.eq("test");
 
-        let routeThree = app.router.routes.GET.find(route => route.spec.path === "/root/routeThree");
+          let routeThree = app.router.routes.GET.find(route => route.spec.path === "/root/routeThree");
+        expect(routeThree).not.to.be.undefined;
+
+    });
+    
+    it("should generate routes for controller methods using defaultRoot", () => {
+
+        @injectable()
+        @Controller("/root")
+        class TestController {
+            @Method("get", "/routeOne")
+            public routeOne() { return; }
+
+            @Method("get", { options: "test", path: "/routeTwo" })
+            public routeTwo() { return; }
+
+            @Method("get", { path: "/routeThree" })
+            public routeThree() { return; }
+        }
+
+        let container = new Container();
+        container.bind(TYPE.Controller).to(TestController);
+        let server = new InversifyRestifyServer(container, {
+            defaultRoot: "/v1"
+        });
+        let app = server.build();
+
+        let routeOne = app.router.routes.GET.find(route => route.spec.path === "/v1/root/routeOne");
+        expect(routeOne).not.to.be.undefined;
+
+        let routeTwo = app.router.routes.GET.find(route => route.spec.path === "/v1/root/routeTwo");
+        expect(routeTwo).not.to.be.undefined;
+        expect((<any>routeTwo).spec.options).to.eq("test");
+
+          let routeThree = app.router.routes.GET.find(route => route.spec.path === "/v1/root/routeThree");
         expect(routeThree).not.to.be.undefined;
 
     });


### PR DESCRIPTION
Added an additional `ServerOptions` parameter that can change default root path from `/` to something different like `/v1` for versioning or something else.

## Description
I've added a `defaultRoot` parameter which can be used to define a default path which will be prepended to all controllers.

## Related Issue
[inversify/InversifyJS#631](https://github.com/inversify/InversifyJS/issues/631)

## Motivation and Context
Where this would be useful is when you're defining path version such as in the example provided above or for instance when you're writing microservices and are using URL load balancing to distinguish between them.

## How Has This Been Tested?
I've added a unit test to `server.test.ts` that checks route generation and I've added an integration test to `framework.test.ts` that checks if `restify.ServerOptions` can be extended with `defaultRoot` parameter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
