### PR TITLE
Injecting middleware

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,44 +1,43 @@
-import * as restify from "restify";
 import { interfaces } from "./interfaces";
 import { METADATA_KEY } from "./constants";
 
-export function Controller(path: string, ...middleware: restify.RequestHandler[]) {
+export function Controller(path: string, ...middleware: interfaces.Middleware[]) {
     return function (target: any) {
         let metadata: interfaces.ControllerMetadata = {path, middleware, target};
         Reflect.defineMetadata(METADATA_KEY.controller, metadata, target);
     };
 }
 
-export function Get(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Get(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("get", options, ...middleware);
 }
 
-export function Post(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Post(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("post", options, ...middleware);
 }
 
-export function Put(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Put(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("put", options, ...middleware);
 }
 
-export function Patch(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Patch(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("patch", options, ...middleware);
 }
 
-export function Head(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Head(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("head", options, ...middleware);
 }
 
-export function Delete(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Delete(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("del", options, ...middleware);
 }
 
-export function Options(options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+export function Options(options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return Method("opts", options, ...middleware);
 }
 
 export function Method(
-        method: string, options: interfaces.RouteOptions, ...middleware: restify.RequestHandler[]): interfaces.HandlerDecorator {
+        method: string, options: interfaces.RouteOptions, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return function (target: any, key: string, value: any) {
         let metadata: interfaces.ControllerMethodMetadata = {options, middleware, method, target, key};
         let metadataList: interfaces.ControllerMethodMetadata[] = [];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,10 +1,13 @@
 import * as restify from "restify";
+import { interfaces as inversifyInterfaces } from "inversify";
 
 namespace interfaces {
 
+    export type Middleware = (inversifyInterfaces.ServiceIdentifier<any> | restify.RequestHandler);
+      
     export interface ControllerMetadata {
         path: string;
-        middleware: restify.RequestHandler[];
+        middleware: Middleware[];
         target: any;
     }
 
@@ -13,7 +16,7 @@ namespace interfaces {
 
     export interface ControllerMethodMetadata {
         options: RouteOptions;
-        middleware: restify.RequestHandler[];
+        middleware: Middleware[];
         target: any;
         method: string;
         key: string;

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -5,7 +5,7 @@ import { interfaces } from "../src/interfaces";
 describe("Unit Test: Controller Decorators", () => {
 
     it("should add controller metadata to a class when decorated with @Controller", (done) => {
-        let middleware = [function() { return; }];
+        let middleware = [function() { return; }, "foo", Symbol("bar")];
         let path = "foo";
 
         @Controller(path, ...middleware)
@@ -21,7 +21,7 @@ describe("Unit Test: Controller Decorators", () => {
 
 
     it("should add method metadata to a class when decorated with @Method", (done) => {
-        let middleware = [function() { return; }];
+        let middleware = [function() { return; }, "bar", Symbol("baz")];
         let path = "foo";
         let method = "get";
 

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -292,5 +292,85 @@ describe("Integration Tests:", () => {
                     done();
                 });
         });
+
+        it("should resolve controller-level middleware", (done) => {
+            const symbolId = Symbol("spyA");
+            const strId = "spyB";
+
+            @injectable()
+            @Controller("/", symbolId, strId)
+            class TestController {
+                @Get("/") public getTest(req: restify.Request, res: restify.Response) { res.send("GET"); }
+            }
+
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+            container.bind<restify.RequestHandler>(symbolId).toConstantValue(spyA);
+            container.bind<restify.RequestHandler>(strId).toConstantValue(spyB);
+
+            server = new InversifyRestifyServer(container);
+
+            request(server.build())
+                .get("/")
+                .expect(200, "GET", function() { 
+                    expect(spyA.calledOnce).to.be.true;
+                    expect(spyB.calledOnce).to.be.true;
+                    expect(result).to.equal("ab");
+                    done();
+                });
+        });
+
+        it("should resolve method-level middleware", (done) => {
+            const symbolId = Symbol("spyA");
+            const strId = "spyB";
+
+            @injectable()
+            @Controller("/")
+            class TestController {
+                @Get("/", symbolId, strId)
+                public getTest(req: restify.Request, res: restify.Response) { res.send("GET"); }
+            }
+
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+            container.bind<restify.RequestHandler>(symbolId).toConstantValue(spyA);
+            container.bind<restify.RequestHandler>(strId).toConstantValue(spyB);
+
+            server = new InversifyRestifyServer(container);
+
+            request(server.build())
+                .get("/")
+                .expect(200, "GET", function() {
+                    expect(spyA.calledOnce).to.be.true;
+                    expect(spyB.calledOnce).to.be.true;
+                    expect(result).to.equal("ab");
+                    done();
+                });
+        });
+
+        it("should compose controller- and method-level middleware", (done) => {
+            const symbolId = Symbol("spyA");
+            const strId = "spyB";
+
+            @injectable()
+            @Controller("/", symbolId)
+            class TestController {
+                @Get("/", strId)
+                public getTest(req: restify.Request, res: restify.Response) { res.send("GET"); }
+            }
+
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+            container.bind<restify.RequestHandler>(symbolId).toConstantValue(spyA);
+            container.bind<restify.RequestHandler>(strId).toConstantValue(spyB);
+
+            server = new InversifyRestifyServer(container);
+
+            request(server.build())
+                .get("/")
+                .expect(200, "GET", function() {
+                    expect(spyA.calledOnce).to.be.true;
+                    expect(spyB.calledOnce).to.be.true;
+                    expect(result).to.equal("ab");
+                    done();
+                });
+        });
     });
 });


### PR DESCRIPTION
Added a feature that enables injecting middleware into controllers
and routes using IOC. The original [implementation](https://github.com/inversify/inversify-express-utils/pull/35) was made by @maxmalov in `inversify-express-utils`.

## Description
I've extended the decorators to support `inversify.ServiceIdentifier` and I've added a middleware resolve method that can inject middleware from IOC container if a user passes a service identifier into a decorator instead of a `restify.RequestHandler`.

## Related Issue
[inversify/inversifyJS#635](https://github.com/inversify/InversifyJS/issues/635)

## Motivation and Context
I think the benefits of adding IOC support to middleware shows when it comes to code maintainability and code testing.

## How Has This Been Tested?
I've updated both tests in `decorators.test.ts` to include `string` and `Symbol` type middleware and I've added three new tests to `framework.test.ts` to check that service identifier are properly converted into request handlers and injected into controllers and routes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
