### PR TITLE
bug fix issue - 636

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ src/syntax/*.d.ts
 
 test/*.js
 test/**/*.js
-src/**/*.js.map
+test/**/*.js.map
 
 type_definitions/**/*.js
 type_definitions/*.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,5 @@
         "**/dist": true,
         "**/docs": true,
         "type_definitions/**/*.js": true
-    },
+    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,6 +117,7 @@ export class InversifyRestifyServer {
                 result.then((value: any) => {
                     if (value && !res.headersSent) {
                         res.send(value);
+                        next();
                     }
                 })
                     .catch((error: any) => {
@@ -125,6 +126,7 @@ export class InversifyRestifyServer {
 
             } else if (result && !res.headersSent) {
                 res.send(result);
+                next();
             }
 
         };

--- a/test/bugs.test.ts
+++ b/test/bugs.test.ts
@@ -1,0 +1,71 @@
+import * as request from "supertest";
+import { InversifyRestifyServer } from "../src/server";
+import { interfaces } from "../src/interfaces";
+import { Controller, Get } from "../src/decorators";
+import { Container, injectable } from "inversify";
+import { TYPE } from "../src/constants";
+import * as sinon from "sinon";
+import { expect } from "chai";
+
+describe("Unit Test: Bugs", () => {
+    let container = new Container();
+    let server: InversifyRestifyServer;
+
+    it("should fire the 'after' event when the controller function returns a Promise", (done) => {
+        @injectable()
+        @Controller("/")
+        class TestController {
+            @Get("/promise") public getTest() {
+                return new Promise(((resolve) => {
+                    setTimeout(resolve, 100, "GET");
+                }));
+            }
+        }
+
+        let spyA = sinon.spy((req: any, res: any) => null);
+
+        container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+        server = new InversifyRestifyServer(container);
+        server.setConfig((app) => {
+            app.on("after", spyA);
+        });
+
+        request(server.build())
+            .get("/noPromise")
+            .set("Accept", "text/plain")
+            .expect(200, "GET", () => {
+                expect(spyA.calledOnce).to.eq(true);
+                done();
+            });
+
+    });
+
+    it("should fire the 'after' event when the controller function returns", (done) => {
+        @injectable()
+        @Controller("/")
+        class TestController {
+            @Get("/noPromise") public getNoPromise() {
+                return "GET";
+            }
+        }
+
+        let spyA = sinon.spy((req: any, res: any) => null);
+
+        container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+        server = new InversifyRestifyServer(container);
+        server.setConfig((app) => {
+            app.on("after", spyA);
+        });
+
+        request(server.build())
+            .get("/")
+            .set("Accept", "text/plain")
+            .expect(200, "GET", () => {
+                expect(spyA.calledOnce).to.eq(true);
+                done();
+            });
+
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
added next() to server.ts in both the Promise and no promise locations

## Related Issue
https://github.com/inversify/InversifyJS/issues/636
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
According to Restify documentation and forums, looks like the 'after' event will fire only if next() is called. See link for more details restify/node-restify#416
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
