### PR TITLE
Changes occurrences of 'Symbol(string)' to 'Symbol.for(string)'

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 const TYPE = {
-    Controller: Symbol("Controller")
+    Controller: Symbol.for("Controller")
 };
 
 const METADATA_KEY = {

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -5,7 +5,7 @@ import { interfaces } from "../src/interfaces";
 describe("Unit Test: Controller Decorators", () => {
 
     it("should add controller metadata to a class when decorated with @Controller", (done) => {
-        let middleware = [function() { return; }, "foo", Symbol("bar")];
+        let middleware = [function() { return; }, "foo", Symbol.for("bar")];
         let path = "foo";
 
         @Controller(path, ...middleware)
@@ -21,7 +21,7 @@ describe("Unit Test: Controller Decorators", () => {
 
 
     it("should add method metadata to a class when decorated with @Method", (done) => {
-        let middleware = [function() { return; }, "bar", Symbol("baz")];
+        let middleware = [function() { return; }, "bar", Symbol.for("baz")];
         let path = "foo";
         let method = "get";
 

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -305,7 +305,7 @@ describe("Integration Tests:", () => {
         });
 
         it("should resolve controller-level middleware", (done) => {
-            const symbolId = Symbol("spyA");
+            const symbolId = Symbol.for("spyA");
             const strId = "spyB";
 
             @injectable()
@@ -331,7 +331,7 @@ describe("Integration Tests:", () => {
         });
 
         it("should resolve method-level middleware", (done) => {
-            const symbolId = Symbol("spyA");
+            const symbolId = Symbol.for("spyA");
             const strId = "spyB";
 
             @injectable()
@@ -358,7 +358,7 @@ describe("Integration Tests:", () => {
         });
 
         it("should compose controller- and method-level middleware", (done) => {
-            const symbolId = Symbol("spyA");
+            const symbolId = Symbol.for("spyA");
             const strId = "spyB";
 
             @injectable()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaces all occurrences of Symbol(string) to Symbol.for(string)

## Related Issue
[inversify #691](https://github.com/inversify/InversifyJS/issues/691)

## Motivation and Context
[See description of a Symbol](https://developer.mozilla.org/en-US/docs/Glossary/Symbol)

Calling `Symbol()` creates a unique primitive value in the Javascript engine. Without a reference to it, it becomes lost.

```
Symbol('foo') === Symbol('foo')  // false

let key1 = Symbol('foo')
let key2 = Symbol('foo')
let obj = {
    [key1]: 'bar',
    [key2]: 'baz'
}
obj[key1] === 'bar' // true
obj[key2] === 'baz' // true 
```
Object keys created using `Symbol()` are therefore impossible to use without keeping a reference to them. 

Using Symbol.for('foobar') looks up the symbol in the JS registry and returns it if found or creates it if not found. 

## How Has This Been Tested?
Didn't create additional code needing coverage

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (Changed tests)
- [x] All new and existing tests passed.
