### PR TITLE
adding __proto__ to fix the metadata lookup

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,7 @@ export class InversifyRestifyServer {
 
             let controllerMetadata: interfaces.ControllerMetadata = Reflect.getOwnMetadata(
                 METADATA_KEY.controller,
-                controller.constructor
+                controller.__proto__.constructor
             );
 
             if (this.defaultRoot !== null && typeof controllerMetadata.path === "string") {


### PR DESCRIPTION
## Description

When used with the ES6 proxies, the controller.constructor will be the Proxy object and thus loses the metadata information which was already present in the underlying class. We use `__proto__` to get the actual object that is used in the lookup chain to resolve methods, and metadata.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

